### PR TITLE
Allow user to override searchtask_list

### DIFF
--- a/plugin/searchtasks.vim
+++ b/plugin/searchtasks.vim
@@ -2,12 +2,12 @@
 " Maintainer:   Gilson Filho <http://gilsondev.com>
 " Version:      1.0
 
-if exists("g:searchtasks_list") || &cp || v:version < 700
+if exists("g:searchtasks_loaded") || &cp || v:version < 700
   finish
 endif
 
 let g:searchtasks_list=["TODO", "FIXME", "XXX"]
-
+let g:searchtasks_loaded=1
 
 " Search tasks {{{
 function s:SearchTasks(directory)

--- a/plugin/searchtasks.vim
+++ b/plugin/searchtasks.vim
@@ -6,8 +6,11 @@ if exists("g:searchtasks_loaded") || &cp || v:version < 700
   finish
 endif
 
-let g:searchtasks_list=["TODO", "FIXME", "XXX"]
 let g:searchtasks_loaded=1
+
+if !exists("g:searchtasks_list")
+  let g:searchtasks_list=["TODO", "FIXME", "XXX"]
+endif
 
 " Search tasks {{{
 function s:SearchTasks(directory)


### PR DESCRIPTION
This solves a bug where the user adds `let g:searchtasks_list=...` in their `.vimrc` file and it gets set before the plugin is loaded, thus calling `finish` on first load.